### PR TITLE
Update Go version to 1.24 and add darwin/arm64 release build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.17
+        go-version: 1.24
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,29 +10,43 @@ jobs:
     name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.24
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1.40
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
         goarch: amd64
+        goversion: 1.24
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.24
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1.40
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
         goarch: amd64
+        goversion: 1.24
+  release-darwin-arm64:
+    name: release darwin/arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1.40
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: darwin
+        goarch: arm64
+        goversion: 1.24
   release-windows-amd64:
     name: release windows/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.24
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1.40
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: windows
         goarch: amd64
+        goversion: 1.24

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sng2c/rpipe
 
-go 1.17
+go 1.24
 
 require (
 	github.com/go-redis/redis/v8 v8.11.4


### PR DESCRIPTION
- go.mod: upgrade minimum Go version from 1.17 to 1.24
- go.yml: update to actions/checkout@v4, setup-go@v5, go 1.24
- release.yaml: add darwin/arm64 job, update all jobs to go 1.24 and latest action versions

https://claude.ai/code/session_017FVUwA1eLEoNPWaFEtFxtn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it raises the minimum supported Go version and changes CI/release tooling, which can break builds for consumers or introduce new compiler/runtime behavior.
> 
> **Overview**
> Upgrades the module’s minimum Go version to `1.24` and updates CI (`go.yml`) to build/test using Go 1.24 with newer `actions/checkout@v4` and `actions/setup-go@v5`.
> 
> Refreshes the release workflow to use `wangyoucao577/go-release-action@v1.40`, pins releases to Go 1.24 across targets, and adds a new `darwin/arm64` release job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16c22fde1b347d4969d272ea92a4ad9695db0b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->