### PR TITLE
Fix release workflow: remove goversion to fix 404 error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
         goarch: amd64
-        goversion: 1.24
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
@@ -27,7 +26,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
         goarch: amd64
-        goversion: 1.24
   release-darwin-arm64:
     name: release darwin/arm64
     runs-on: ubuntu-latest
@@ -38,7 +36,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: darwin
         goarch: arm64
-        goversion: 1.24
   release-windows-amd64:
     name: release windows/amd64
     runs-on: ubuntu-latest
@@ -49,4 +46,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: windows
         goarch: amd64
-        goversion: 1.24


### PR DESCRIPTION
## 문제\n\n`goversion: 1.24` 설정 시 `go1.24.linux-amd64.tar.gz` 다운로드 시도 → 404 오류 발생.\nGo 릴리즈는 `1.24.0`, `1.24.1` 처럼 패치 버전이 필요함.\n\n## 수정\n\n`goversion` 필드를 제거하여 go-release-action이 자동으로 최신 Go 버전(현재 1.26.1)을 사용하도록 변경.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; risk is limited to release build reproducibility if the action’s default Go version changes over time.
> 
> **Overview**
> Fixes the GitHub Release workflow by **removing the pinned `goversion: 1.24`** from all `go-release-action` jobs so the action can resolve a valid Go toolchain version automatically (avoiding the 404 on `go1.24.*` downloads).
> 
> This changes only CI/release packaging behavior for `linux/darwin/windows` builds; no application code is modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b8e49d88880c5ef1f6193924720222599998d45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->